### PR TITLE
Use `main` branch instead of `master`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Options:
 By default a config file will be generated in `~/.config/tldr`:
 
 ```toml
-page_source = "https://raw.githubusercontent.com/tldr-pages/tldr/master/pages"
+page_source = "https://raw.githubusercontent.com/tldr-pages/tldr/main/pages"
 language = "en"
 proxy_url = ""
 

--- a/src/py_tldr/core.py
+++ b/src/py_tldr/core.py
@@ -26,7 +26,7 @@ except ModuleNotFoundError:
 VERSION_CLIENT_SPEC = "1.5"
 DEFAULT_CACHE_HOURS = 24
 DEFAULT_CONFIG = {
-    "page_source": "https://raw.githubusercontent.com/tldr-pages/tldr/master/pages",
+    "page_source": "https://raw.githubusercontent.com/tldr-pages/tldr/main/pages",
     "language": "",
     "cache": {
         "enabled": True,
@@ -192,7 +192,7 @@ def get_languages(language: str) -> List[str]:
     Otherwise make the list based on env `LANG` and
     `LANGUAGE`.
     # pylint: disable=line-too-long
-    For detailed logic, see https://github.com/tldr-pages/tldr/blob/master/CLIENT-SPECIFICATION.md#language  # noqa
+    For detailed logic, see https://github.com/tldr-pages/tldr/blob/main/CLIENT-SPECIFICATION.md#language  # noqa
     """
     if language:
         return [language]


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the master branch in favor of the main branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).