### PR TITLE
Fix page searching logic

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2023-07-20
+### Changed
+- Fix `FileNotFoundError` when caching for different languages.
+- Use `targets` in index file for searching.
+
 ## [0.8.0] - 2023-07-15
 ### Added
 - Support for language and platform in config file.

--- a/src/py_tldr/__init__.py
+++ b/src/py_tldr/__init__.py
@@ -4,7 +4,7 @@ from os import environ
 from .core import cli
 from .page import PageCache, PageFinder, PageFormatter
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 
 logging_config = {

--- a/src/py_tldr/core.py
+++ b/src/py_tldr/core.py
@@ -11,8 +11,8 @@ from click import command as command_
 from yaspin import yaspin
 from yaspin.spinners import Spinners
 
-from .page import DownloadError, PageFinder, PageFormatter
-from .parse import parse_command, parse_language, parse_platform
+from py_tldr.page import DownloadError, PageFinder, PageFormatter
+from py_tldr.parse import parse_command, parse_language, parse_platform
 
 try:
     from importlib.metadata import version

--- a/src/py_tldr/page.py
+++ b/src/py_tldr/page.py
@@ -1,4 +1,5 @@
 import json
+from collections import defaultdict
 from datetime import datetime
 from http import HTTPStatus
 from logging import getLogger
@@ -101,10 +102,10 @@ class PageCache:
         )
         index, index_compact = json.loads(data), {}
         for command in index["commands"]:
-            index_compact[command["name"]] = {
-                "platforms": command["platform"],
-                "languages": command["language"],
-            }
+            name = command["name"]
+            index_compact[name] = defaultdict(list)
+            for target in command["targets"]:
+                index_compact[name][target["os"]].append(target["language"])
         with open(self.index_file, "w") as f:
             json.dump(index_compact, f)
 
@@ -198,22 +199,24 @@ class PageFinder:
         self, name: str, platform: str = "", languages: List[str] = None
     ) -> Tuple[str, str, str]:
         """Search index for the best platform and language for the command."""
-        index = self.get_index()
-        info = index.get(name)
+        info = self.get_index().get(name)
         if not info:
             return "", "", ""
 
-        platforms = info["platforms"]
-        if platform not in platforms:
-            platform = "common" if "common" in platforms else platforms[0]
-
-        language = ""
-        languages_info = info["languages"]
-        for lang in languages:
-            if lang in languages_info:
-                language = lang
+        platforms = list(info.keys())
+        for pf in [platform, "common"]:
+            if pf in platforms:
+                platforms.remove(pf)
+        res_platform, res_language = "", ""
+        for pf in [platform, "common"] + platforms:
+            if pf in info:
+                for lang in languages:
+                    if lang in info[pf]:
+                        res_platform, res_language = pf, lang
+                        break
+            if res_platform and res_language:
                 break
-        return name, platform, language
+        return name, res_platform, res_language
 
     def sync(self, language: str) -> None:
         self.cache.update(language)

--- a/src/py_tldr/page.py
+++ b/src/py_tldr/page.py
@@ -61,8 +61,8 @@ class PageCache:
         return res
 
     def set(self, name: str, platform: str, content: str, language: str = "en"):
-        (self.location / platform).mkdir(parents=True, exist_ok=True)
         page_file = self._make_page_file(platform, name, language)
+        page_file.parent.mkdir(parents=True, exist_ok=True)
         with open(page_file, "w", encoding="utf8") as f:
             f.write(content)
 

--- a/tests/unit/test_page.py
+++ b/tests/unit/test_page.py
@@ -24,14 +24,19 @@ class TestPageCache:
             return_value=json.dumps(
                 {
                     "commands": [
-                        {"name": "tldr", "platform": ["linux"], "language": ["en"]}
+                        {
+                            "name": "tldr",
+                            "platform": ["linux"],
+                            "language": ["en"],
+                            "targets": [{"os": "linux", "language": "en"}],
+                        }
                     ]
                 }
             ),
         )
         cache.update_index()
         with open(cache.index_file) as f:
-            assert json.load(f)["tldr"] == {"platforms": ["linux"], "languages": ["en"]}
+            assert json.load(f)["tldr"] == {"linux": ["en"]}
         assert cache.check_index() is True
 
 
@@ -109,34 +114,50 @@ class TestPageFinder:
                 ("", "", ""),
             ),
             (
-                {"tldr": {"platforms": ["common", "linux"], "languages": ["en"]}},
+                {"tldr": {"linux": ["en"], "common": ["en"]}},
                 ("tldr", "linux", ["en"]),
                 ("tldr", "linux", "en"),
             ),
             (
-                {"tldr": {"platforms": ["common", "linux"], "languages": ["en"]}},
+                {"tldr": {"linux": ["en"], "common": ["en"]}},
                 ("tldr", "osx", ["en"]),
                 ("tldr", "common", "en"),
             ),
             (
-                {"tldr": {"platforms": ["linux"], "languages": ["en"]}},
+                {
+                    "tldr": {
+                        "linux": ["en"],
+                    }
+                },
                 ("tldr", "osx", ["en"]),
                 ("tldr", "linux", "en"),
             ),
             (
-                {"tldr": {"platforms": ["linux"], "languages": ["en"]}},
+                {
+                    "tldr": {
+                        "linux": ["en"],
+                    }
+                },
                 ("tldr", "linux", ["en"]),
                 ("tldr", "linux", "en"),
             ),
             (
-                {"tldr": {"platforms": ["linux"], "languages": ["en"]}},
+                {
+                    "tldr": {
+                        "linux": ["en"],
+                    }
+                },
                 ("tldr", "linux", ["zh", "en"]),
                 ("tldr", "linux", "en"),
             ),
             (
-                {"tldr": {"platforms": ["linux"], "languages": ["en"]}},
+                {
+                    "tldr": {
+                        "linux": ["en"],
+                    }
+                },
                 ("tldr", "linux", ["zh"]),
-                ("tldr", "linux", ""),
+                ("tldr", "", ""),
             ),
         ),
     )


### PR DESCRIPTION
- Directory should exists for every language, such as `pt_BR`.
- Use `targets` in the index file for searching, which lists all the existed pair matches for both platforms and languages.
